### PR TITLE
fix: topical shows match Sonarr searches + clipboard fallback (#20, partial #21)

### DIFF
--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -1,6 +1,7 @@
 import { createSignal, onMount, Show } from "solid-js";
 import { api } from "../api";
 import { getSonarrSetup } from "../lib/sonarr-setup";
+import { copyToClipboard } from "../lib/clipboard";
 import type { ConfigResponse } from "../types";
 
 export default function SetupWizard(props: { show: boolean; onComplete: () => void }) {
@@ -39,11 +40,11 @@ export default function SetupWizard(props: { show: boolean; onComplete: () => vo
     }
   }
 
-  function copyField(text: string, key: string) {
-    navigator.clipboard.writeText(text).then(() => {
-      setCopiedField(key);
-      setTimeout(() => setCopiedField(null), 2000);
-    });
+  async function copyField(text: string, key: string) {
+    const ok = await copyToClipboard(text);
+    if (!ok) return;
+    setCopiedField(key);
+    setTimeout(() => setCopiedField(null), 2000);
   }
 
   function stepClass(n: number) {

--- a/frontend/src/lib/clipboard.ts
+++ b/frontend/src/lib/clipboard.ts
@@ -1,0 +1,30 @@
+// copyToClipboard writes text to the system clipboard with a fallback
+// for non-secure contexts. navigator.clipboard only works over HTTPS or
+// localhost; iplayer-arr is typically reached over plain HTTP on a LAN
+// IP, where the modern API silently rejects. Fall back to a hidden
+// textarea + execCommand so copy buttons still work. See GitHub issue #21.
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    if (window.isSecureContext && navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // fall through to legacy path
+  }
+  try {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    ta.style.position = "fixed";
+    ta.style.top = "-1000px";
+    ta.style.opacity = "0";
+    document.body.appendChild(ta);
+    ta.focus();
+    ta.select();
+    const ok = document.execCommand("copy");
+    document.body.removeChild(ta);
+    return ok;
+  } catch {
+    return false;
+  }
+}

--- a/frontend/src/pages/Config.tsx
+++ b/frontend/src/pages/Config.tsx
@@ -4,6 +4,7 @@ import { QUALITY_OPTIONS } from "../types";
 import { api } from "../api";
 import { addToast } from "../toast";
 import { getSonarrSetup } from "../lib/sonarr-setup";
+import { copyToClipboard } from "../lib/clipboard";
 
 export default function Config() {
   const workerOptions = ["1", "2", "3", "5", "10", "15", "20"];
@@ -16,8 +17,9 @@ export default function Config() {
     setConfig(await api.getConfig());
   });
 
-  function copyField(value: string, key: string) {
-    navigator.clipboard.writeText(value);
+  async function copyField(value: string, key: string) {
+    const ok = await copyToClipboard(value);
+    if (!ok) return;
     setCopiedField(key);
     setTimeout(() => setCopiedField(null), 2000);
   }

--- a/internal/newznab/handler_test.go
+++ b/internal/newznab/handler_test.go
@@ -246,6 +246,44 @@ func TestHandleTVSearchDailyMatchByDate(t *testing.T) {
 	}
 }
 
+func TestHandleTVSearchTopicalWeeklyFallbackToDate(t *testing.T) {
+	// GitHub #20: Sonarr searches Question Time with standard integer
+	// season/ep (season=48&ep=23) because TVDB numbers the show. BBC
+	// iPlayer reports topical/weekly shows with no series/episode
+	// numbering (Series=0, EpisodeNum=0) but a valid release_date. A
+	// strict integer-S/E filter returned zero items, so Sonarr could
+	// never match it even though the in-app search found the episode.
+	// The handler must fall back to a date-tier release so the user can
+	// set the Sonarr series type to "Daily" and match by air date.
+	payload := `{
+		"new_search": {
+			"results": [
+				{"id": "qt1", "type": "episode", "title": "Question Time", "subtitle": "26/03/2026", "release_date": "2026-03-26", "parent_position": 23}
+			]
+		}
+	}`
+	h := newHandlerWithBBC(t, payload)
+	req := httptest.NewRequest("GET", "/newznab/api?t=tvsearch&q=question+time&season=48&ep=23", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("status = %d", w.Code)
+	}
+	titles := itemTitles(w.Body.String())
+	if len(titles) == 0 {
+		t.Fatalf("expected at least one item for topical fallback, got empty body:\n%s", w.Body.String())
+	}
+	for _, title := range titles {
+		if !strings.Contains(title, "Question.Time.2026.03.26") {
+			t.Errorf("title = %q, want it to contain %q", title, "Question.Time.2026.03.26")
+		}
+		if strings.Contains(title, "S48E23") {
+			t.Errorf("title = %q must not claim S/E numbering iPlayer did not provide", title)
+		}
+	}
+}
+
 func TestHandleTVSearchDailyMismatchByDate(t *testing.T) {
 	// Wrong date should return zero items.
 	h := newHandlerWithBBC(t, eastendersOneEpisodePayload)
@@ -549,6 +587,16 @@ func TestMatchesSearchFilter_TableDriven(t *testing.T) {
 		{"season+ep mismatch", &store.Programme{Name: "Doctor Who", Series: 14, EpisodeNum: 2}, "doctor who", "", 14, 3, false},
 		{"daily date match", &store.Programme{Name: "Newsnight", AirDate: "2026-04-05"}, "newsnight", "2026-04-05", 0, 0, true},
 		{"daily date mismatch", &store.Programme{Name: "Newsnight", AirDate: "2026-04-04"}, "newsnight", "2026-04-05", 0, 0, false},
+		// Topical/weekly fallback: programme has no S/E numbering but a
+		// valid AirDate. Sonarr sends integer season/ep (from TVDB) but
+		// iPlayer never numbered the show. Must pass so the emit loop
+		// produces a date-tier title. GitHub #20.
+		{"topical weekly no numbering passes integer filter",
+			&store.Programme{Name: "Question Time", AirDate: "2026-03-26"},
+			"question time", "", 48, 23, true},
+		{"topical without air date still rejected",
+			&store.Programme{Name: "Question Time"},
+			"question time", "", 48, 23, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/newznab/search.go
+++ b/internal/newznab/search.go
@@ -407,6 +407,17 @@ func matchesSearchFilter(prog *store.Programme, wantName, filterDate string, fil
 	if filterDate != "" {
 		return prog.AirDate == filterDate
 	}
+	// Topical/weekly escape hatch. Shows like Question Time or Newsnight
+	// arrive from iPlayer with no series/episode numbering (Series=0,
+	// EpisodeNum=0) but a valid AirDate. A strict integer-S/E filter
+	// would reject every such release, which is why Sonarr's interactive
+	// search returns nothing even though the in-app search finds the
+	// episode. Accept them so GenerateTitle can emit a date-tier title;
+	// the user must set the series type to "Daily" in Sonarr for it to
+	// match by air date. See GitHub issue #20.
+	if prog.Series == 0 && prog.EpisodeNum == 0 && prog.AirDate != "" {
+		return true
+	}
 	if filterSeason > 0 && prog.Series != filterSeason {
 		return false
 	}


### PR DESCRIPTION
## Summary

Two independent bug fixes heading for v1.1.2.

### #20, Sonarr can't find topical/weekly shows

BBC iPlayer returns topical shows like Question Time and Newsnight with no series/episode numbering (`Series=0`, `EpisodeNum=0`), only a release date. TVDB numbers them, so Sonarr sent `season=48&ep=23` for Question Time s48e23 and the `matchesSearchFilter` helper rejected every result because `Series(0) != 48`. The in-app search worked because it only matches by name.

Fix: accept zero-numbered programmes that have a valid `AirDate`, so the existing tier-3 date fallback in `GenerateTitle` fires. The emitted release is `Question.Time.2026.03.26.1080p.BBC.WEB-DL.x264-iPLAYER`, which Sonarr matches when the series is set to **Series Type: Daily** (same mechanism the BBC daily soaps already rely on). This will be called out in the v1.1.2 release notes.

### #21, Copy buttons silently fail (partial)

Root cause: `navigator.clipboard.writeText()` only works in a secure context. iplayer-arr is typically reached over plain HTTP on a LAN IP, so every copy button across every browser silently rejected. Not environment-specific.

Fix: new `frontend/src/lib/clipboard.ts` helper that tries the modern API first and falls back to a hidden `<textarea>` + `document.execCommand('copy')` when the secure-context check fails. Both `copyField` callers (`Config.tsx`, `SetupWizard.tsx`) now route through it.

The second half of #21 (manual-download Delete button inert) is **not** in this PR. It needs a repro bundle from the reporter to confirm whether it's a trailing-slash mismatch, symlink resolution, or an empty `OutputDir` on the manual path. Comment with the diagnostic request is up on the issue.

## Changes

- `internal/newznab/search.go`, topical/weekly escape hatch in `matchesSearchFilter`
- `internal/newznab/handler_test.go`, new `TestHandleTVSearchTopicalWeeklyFallbackToDate` plus two table cases
- `frontend/src/lib/clipboard.ts`, new secure-context-aware helper
- `frontend/src/pages/Config.tsx`, `frontend/src/components/SetupWizard.tsx`, use the helper

## Test plan

- [x] `go test ./internal/newznab/`, 68 tests pass, including the new coverage
- [x] `npm run build`, clean vite build, no regressions
- [x] `npm run test`, vitest suite green
- [x] Gitea CI run 421, green
- [ ] Manual verify on a clean iplayer-arr instance after merge: Sonarr interactive search for a topical show (set to Daily series type) returns date-based releases
- [ ] Manual verify: copy buttons work over plain HTTP on the LAN