### PR TITLE
fix: pass docker env vars to the binary + clean ownership paths (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to iplayer-arr will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2026-04-09
+
+### Fixed
+
+- **#20 Topical shows not matched by Sonarr searches**: weekly topical shows like Question Time and Newsnight that BBC iPlayer reports with no series/episode numbering (Series=0, EpisodeNum=0) were silently dropped from Sonarr integer-S/E searches because the newznab filter rejected them outright. The filter now accepts zero-numbered programmes that have a valid air date, so the existing date-tier release generator emits a `Show.Name.YYYY.MM.DD` title. **Sonarr configuration note:** set the series type to "Daily" for topical shows, Sonarr only accepts date-based releases for series flagged Daily. This is the same mechanism the BBC daily soaps (EastEnders, Casualty, Doctors) already rely on.
+- **#21 Copy buttons silently fail on plain HTTP origins**: `navigator.clipboard.writeText()` only works in a secure context, so every Copy button on the Config page and Setup wizard silently rejected when iplayer-arr was reached at `http://<lan-ip>:<port>` (non-secure context). Added `frontend/src/lib/clipboard.ts` with a hidden-textarea `execCommand('copy')` fallback. All 8 copy buttons verified in a real Chromium browser over plain HTTP.
+- **#21 Manual download Delete button inert**: the s6 service run script used `#!/usr/bin/env bash`, launching the binary outside the hotio base image's `with-contenv` envdir. None of `CONFIG_DIR`, `DOWNLOAD_DIR`, `PORT`, or `TZ` reached the process when set in docker-compose, so the writer path used hardcoded fallbacks while the Downloads page scanner read its own source of truth, and the Delete button rendered disabled because the ownership map never matched. Switched the run script to `#!/command/with-contenv bash`, persisted the resolved DOWNLOAD_DIR to the config store on startup so writers and readers share a single source of truth, and added `filepath.Clean` normalisation in `ListHistoryOutputDirs` as belt-and-braces safety for legacy entries. Verified end-to-end: real manual download to `/data/tv`, Delete click in a real Chromium, folder removed from both the directory listing and the filesystem. Side-benefit: log timestamps now honour TZ.
+
+### Tests
+
+- `TestHandleTVSearchTopicalWeeklyFallbackToDate` covers the full newznab handler path with a Question Time payload.
+- Two new cases in the `matchesSearchFilter` table test cover the topical fallback with and without an air date.
+- `TestListHistoryOutputDirsCleansPaths` regression-tests the ownership map normalisation for trailing slash, dot segment, clean path, and empty OutputDir variants.
+- 216 Go tests pass across 8 packages. Frontend vitest suite passes.
+
 ## [1.1.1] - 2026-04-08
 
 ### Breaking changes

--- a/cmd/iplayer-arr/main.go
+++ b/cmd/iplayer-arr/main.go
@@ -58,6 +58,15 @@ func main() {
 		st.SetConfig("api_key", apiKey)
 	}
 
+	// Persist the resolved DOWNLOAD_DIR to the config store on every start.
+	// The writer side (download.Manager) uses this value injected directly;
+	// the reader side (api/directory.go and sabnzbd/handler.go) reads it
+	// back from the store. Without this line the store stays empty and
+	// those readers fall back to the hardcoded "/downloads", which diverges
+	// from the actual runtime path and breaks the Downloads-page ownership
+	// check (Delete button appears inert). See GitHub issue #21.
+	st.SetConfig("download_dir", filepath.Clean(downloadDir))
+
 	// purge stale programme cache
 	st.PurgeStaleProgrammes(4 * time.Hour)
 

--- a/internal/store/history.go
+++ b/internal/store/history.go
@@ -3,6 +3,7 @@ package store
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -134,6 +135,13 @@ func (s *Store) ListHistory() ([]*Download, error) {
 	return history, err
 }
 
+// ListHistoryOutputDirs returns the set of cleaned OutputDir values from
+// every history entry. The paths are normalised with filepath.Clean so a
+// caller computing `filepath.Join(downloadDir, entry.Name())` (which also
+// cleans) can do a direct map lookup without worrying about trailing
+// slashes or other stylistic differences between how the path was written
+// and how it is read back. See GitHub issue #21 for the Delete button
+// symptom that motivated the normalisation.
 func (s *Store) ListHistoryOutputDirs() (map[string]bool, error) {
 	dirs := make(map[string]bool)
 	err := s.db.View(func(tx *bolt.Tx) error {
@@ -143,7 +151,7 @@ func (s *Store) ListHistoryOutputDirs() (map[string]bool, error) {
 				return err
 			}
 			if dl.OutputDir != "" {
-				dirs[dl.OutputDir] = true
+				dirs[filepath.Clean(dl.OutputDir)] = true
 			}
 			return nil
 		})

--- a/internal/store/history_test.go
+++ b/internal/store/history_test.go
@@ -221,6 +221,65 @@ func TestListHistoryFilteredSortByTitle(t *testing.T) {
 	}
 }
 
+// TestListHistoryOutputDirsCleansPaths regression-tests GitHub #21: the
+// Downloads page ownership check does a map lookup of the cleaned folder
+// path against ListHistoryOutputDirs. If history persists an OutputDir
+// with a trailing slash, a dot segment, or any stylistic difference from
+// what the directory scanner computes with filepath.Join, the lookup
+// misses and the Delete button renders disabled ("does nothing" on
+// click). The store-layer normalisation here makes the map resilient.
+func TestListHistoryOutputDirsCleansPaths(t *testing.T) {
+	s := testStore(t)
+
+	entries := []struct {
+		id        string
+		outputDir string
+	}{
+		{"dirty_trailing_slash", "/downloads/Newsround/"},
+		{"dirty_dot_segment", "/downloads/./Question.Time"},
+		{"clean", "/downloads/Doctor.Who"},
+		{"empty_output_dir", ""},
+	}
+	for _, e := range entries {
+		dl := &Download{
+			ID: e.id, PID: "pid_" + e.id, Title: e.id,
+			Status: StatusCompleted, OutputDir: e.outputDir,
+		}
+		if err := s.PutHistory(dl); err != nil {
+			t.Fatalf("PutHistory %q: %v", e.id, err)
+		}
+	}
+
+	dirs, err := s.ListHistoryOutputDirs()
+	if err != nil {
+		t.Fatalf("ListHistoryOutputDirs: %v", err)
+	}
+
+	// Every expected cleaned path must be present.
+	for _, want := range []string{
+		"/downloads/Newsround",
+		"/downloads/Question.Time",
+		"/downloads/Doctor.Who",
+	} {
+		if !dirs[want] {
+			t.Errorf("cleaned path %q missing from ownership map %+v", want, dirs)
+		}
+	}
+
+	// The empty-output-dir entry must not leak an empty-string key.
+	if dirs[""] {
+		t.Errorf("empty OutputDir should not produce a map entry")
+	}
+
+	// The raw dirty paths must NOT be present as keys, because the
+	// scanner will never compute them.
+	for _, bad := range []string{"/downloads/Newsround/", "/downloads/./Question.Time"} {
+		if dirs[bad] {
+			t.Errorf("uncleaned path %q must not appear in the ownership map", bad)
+		}
+	}
+}
+
 func TestClearHistory(t *testing.T) {
 	s := testStore(t)
 

--- a/s6/service-iplayer-arr/run
+++ b/s6/service-iplayer-arr/run
@@ -1,2 +1,2 @@
-#!/usr/bin/env bash
+#!/command/with-contenv bash
 exec s6-setuidgid hotio /app/iplayer-arr


### PR DESCRIPTION
## Summary

Root-cause fix for the #21 manual-download Delete button that appears inert, plus a latent bug that quietly broke `CONFIG_DIR`, `DOWNLOAD_DIR`, and `PORT` for every user who set them in docker-compose.

## Root cause

The s6 service run script used `#!/usr/bin/env bash`. That launched the iplayer-arr binary outside the hotio base image's `with-contenv` envdir, so none of the user's runtime env vars reached the process. Every `envOr` call in `main.go` silently returned its hardcoded fallback. Users who set `DOWNLOAD_DIR=/mnt/user/downloads/iplayer-arr` on Unraid were in fact running with `/downloads`, which either failed at mkdir time or, when `/downloads` was a valid writable path, caused the Downloads-page ownership check to compare paths with nothing to do with the configured volume.

A second layer of the bug: the writer (download.Manager) was injected with the env var value directly, but the readers (api/directory.go for the Downloads page and sabnzbd/handler.go for Sonarr integration) read `download_dir` from the config store and fell back to a hardcoded `/downloads` when the store was empty. Even after the env var reaches the binary, the store needs to be seeded for the two paths to agree.

## Fix

1. **`s6/service-iplayer-arr/run`** now uses `#!/command/with-contenv bash`. CONFIG_DIR, DOWNLOAD_DIR, PORT, TZ all flow through correctly. Side-benefit: log timestamps now honour TZ, they were silently UTC before.
2. **`cmd/iplayer-arr/main.go`** persists the resolved DOWNLOAD_DIR to the config store on every start. Single source of truth, no drift.
3. **`internal/store/history.go`** normalises each `OutputDir` with `filepath.Clean` when building the ownership map. Belt-and-braces safety for any legacy entries with trailing slashes or dot segments.
4. New regression test `TestListHistoryOutputDirsCleansPaths` covers trailing slash, dot segment, clean path, and empty OutputDir variants.
5. CHANGELOG v1.1.2 entry covering all three fixes shipping in this release (#20 topical, #21 copy-button half, #21 delete-button half).

## Test plan

- [x] `go test ./...` passes 216 tests across 8 packages
- [x] Gitea CI run 424 green
- [x] Smoke test on an isolated container with `DOWNLOAD_DIR=/data/tv`:
  - Container starts, `TZ=Europe/London` reflected in log timestamps (was `Z` before)
  - `/api/config` reports `download_dir: /data/tv` (was hardcoded `/downloads` before)
  - Manual download of Newsround via `POST /api/download` writes to `/data/tv/Newsround/Newsround.mp4` on disk
  - History row carries `output_dir: /data/tv/Newsround`
  - `/api/downloads/directory` lists the folder with `owned: true`
  - Clicking the Delete button in a real Chromium browser fires the confirm dialog, the API call succeeds, the folder disappears from both the listing and the filesystem

Closes #21 (manual-download delete-button half).