### PR TITLE
v1.1.5: Sonarr RSS correctness + dashboard polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to iplayer-arr will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **TVDB ID echoed in RSS responses**: iplayer-arr now includes `<newznab:attr name="tvdbid" />` in search results, giving Sonarr a definitive series match. Previously, Sonarr relied on title parsing which failed for ambiguous names like "Return to Paradise" vs "Paradise".
+- **Redundant `Series.N.M` in release titles confuses Sonarr**: the episode subtitle (e.g. `Series 2: 1. Apex Predator`) was included verbatim after the `SxxExx` tag, producing titles like `S02E01.Series.2.1.Apex.Predator` that Sonarr misparses. The `Series N: M.` prefix is now stripped since the numbering is already in `SxxExx`.
+- **Episode titles containing colons break subtitle parser**: subtitles like `Series 2: 5. Chapter One: Murder` were split at all `": "` delimiters (limit 3), causing the episode number to be lost. Changed to split at the first colon only so episode titles with colons are handled correctly.
+- **Dashboard overflow**: active downloads and queue sections now cap at 400px/300px with thin internal scrollbars. Removed `overflow-x: hidden` from `.main` which was preventing natural page scroll.
+- **Queue section not appearing dynamically**: SSE events for new pending downloads were routed to the active list instead of the queue, so the Queue card never appeared without a page refresh.
+- **Long titles in dashboard**: download titles and history table now truncate with ellipsis instead of wrapping across multiple lines.
+
 ## [1.1.4] - 2026-04-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.5] - 2026-04-14
+
 ### Fixed
 
 - **TVDB ID echoed in RSS responses**: iplayer-arr now includes `<newznab:attr name="tvdbid" />` in search results, giving Sonarr a definitive series match. Previously, Sonarr relied on title parsing which failed for ambiguous names like "Return to Paradise" vs "Paradise".

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -136,6 +136,21 @@ export default function Dashboard() {
   }
 
   function updateDownload(data: Download) {
+    if (data.status === "pending") {
+      // New or still-pending download belongs in the queue
+      setQueue((prev) => {
+        const idx = prev.findIndex((d) => d.id === data.id);
+        if (idx >= 0) {
+          const next = [...prev];
+          next[idx] = data;
+          return next;
+        }
+        return [...prev, data];
+      });
+      setActive((prev) => prev.filter((d) => d.id !== data.id));
+      return;
+    }
+    // Non-pending: move to active, remove from queue
     setActive((prev) => {
       const idx = prev.findIndex((d) => d.id === data.id);
       if (idx >= 0) {
@@ -143,10 +158,8 @@ export default function Dashboard() {
         next[idx] = data;
         return next;
       }
-      // Might be moving from queue to active
       return [...prev, data];
     });
-    // Remove from queue if present
     setQueue((prev) => prev.filter((d) => d.id !== data.id));
   }
 
@@ -343,7 +356,7 @@ export default function Dashboard() {
       {/* Active downloads */}
       <div class="card">
         <div class="card-header">Active Downloads</div>
-        <div class="card-body">
+        <div class="card-body scroll-thin" style={{ "max-height": "400px" }}>
           <Show when={active().length > 0} fallback={<div class="card-empty">No active downloads</div>}>
             <For each={active()}>
               {(dl) => (
@@ -398,7 +411,7 @@ export default function Dashboard() {
       <Show when={queue().length > 0}>
         <div class="card">
           <div class="card-header">Queue ({queue().length})</div>
-          <div class="card-body">
+          <div class="card-body scroll-thin" style={{ "max-height": "300px" }}>
             <For each={queue()}>
               {(dl) => (
                 <div class="dl-item">
@@ -482,11 +495,12 @@ export default function Dashboard() {
                         : "▼"
                       : ""}
                   </th>
-                  <th scope="col" class="text-center">Quality</th>
-                  <th scope="col" class="text-center">Status</th>
+                  <th scope="col" class="text-center" style={{ width: "60px" }}>Quality</th>
+                  <th scope="col" class="text-center" style={{ width: "80px" }}>Status</th>
                   <th
                     scope="col"
                     data-sortable
+                    style={{ width: "100px" }}
                     onClick={() => toggleSort("completed_at")}
                   >
                     Completed{" "}
@@ -496,8 +510,8 @@ export default function Dashboard() {
                         : "▼"
                       : ""}
                   </th>
-                  <th scope="col" class="text-center">Size</th>
-                  <th scope="col"></th>
+                  <th scope="col" class="text-center" style={{ width: "55px" }}>Size</th>
+                  <th scope="col" style={{ width: "55px" }}></th>
                 </tr>
               </thead>
               <tbody>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -24,7 +24,7 @@
 }
 
 html, body, #root {
-  height: 100%;
+  min-height: 100%;
 }
 
 body {
@@ -47,9 +47,18 @@ body {
   margin-left: var(--nav-width);
   padding: 24px 32px;
   max-width: 1200px;
-  overflow-x: hidden;
   transition: margin-left 0.2s;
 }
+
+/* Thin scrollbar for scrollable card sections */
+.scroll-thin {
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+.scroll-thin::-webkit-scrollbar { width: 4px; }
+.scroll-thin::-webkit-scrollbar-track { background: transparent; }
+.scroll-thin::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
 
 /* Navigation */
 .nav {
@@ -277,6 +286,10 @@ body {
 .dl-title {
   font-size: 14px;
   font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 .dl-meta {
@@ -292,6 +305,13 @@ body {
   width: 100%;
   border-collapse: collapse;
   font-size: 13px;
+  table-layout: fixed;
+}
+
+.table td:first-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .table th {

--- a/internal/bbc/ibl.go
+++ b/internal/bbc/ibl.go
@@ -318,9 +318,9 @@ func parseSubtitleNumbers(subtitle string) (series, episode int) {
 		series, _ = strconv.Atoi(m[1])
 	}
 
-	parts := strings.SplitN(subtitle, ": ", 3)
+	parts := strings.SplitN(subtitle, ": ", 2)
 	if len(parts) >= 2 {
-		epPart := parts[len(parts)-1]
+		epPart := parts[1]
 		if reDateEpPart.MatchString(epPart) {
 			// epPart is itself a date; the leading digits are day-of-month,
 			// not episode number. Leave episode = 0. See issue #15.

--- a/internal/newznab/search.go
+++ b/internal/newznab/search.go
@@ -32,7 +32,7 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.writeResultsRSS(w, r, results, 0, 0, "", filterName, 0)
+	h.writeResultsRSS(w, r, results, 0, 0, "", filterName, 0, "")
 }
 
 func (h *Handler) handleTVSearch(w http.ResponseWriter, r *http.Request) {
@@ -104,7 +104,7 @@ func (h *Handler) handleTVSearch(w http.ResponseWriter, r *http.Request) {
 	// so detect the daily shape and filter by air date instead.
 	filterDate := parseDailySearchDate(seasonStr, epStr)
 
-	h.writeResultsRSS(w, r, results, season, ep, filterDate, filterName, filterYear)
+	h.writeResultsRSS(w, r, results, season, ep, filterDate, filterName, filterYear, tvdbid)
 }
 
 // parseDailySearchDate returns YYYY-MM-DD when season looks like a 4-digit
@@ -133,7 +133,7 @@ func parseDailySearchDate(seasonStr, epStr string) string {
 	return fmt.Sprintf("%04d-%02d-%02d", year, mm, dd)
 }
 
-func (h *Handler) writeResultsRSS(w http.ResponseWriter, r *http.Request, results []bbc.IBLResult, filterSeason, filterEp int, filterDate, filterName string, filterYear int) {
+func (h *Handler) writeResultsRSS(w http.ResponseWriter, r *http.Request, results []bbc.IBLResult, filterSeason, filterEp int, filterDate, filterName string, filterYear int, tvdbid string) {
 	var items []string
 	wantName := strings.TrimSpace(filterName)
 
@@ -263,6 +263,10 @@ func (h *Handler) writeResultsRSS(w http.ResponseWriter, r *http.Request, result
       <newznab:attr name="language" value="en" />`,
 				html.EscapeString(title), baseURL(r), guid, baseURL(r), guid, pubDate,
 				baseURL(r), guid, size, cat, size)
+
+			if tvdbid != "" {
+				item += fmt.Sprintf("\n      <newznab:attr name=\"tvdbid\" value=\"%s\" />", tvdbid)
+			}
 
 			if tier == store.TierManual {
 				item += `

--- a/internal/newznab/titles.go
+++ b/internal/newznab/titles.go
@@ -24,6 +24,11 @@ var (
 	// format). Anchored so it does not false-positive on episode titles
 	// that merely contain a date substring.
 	reCompositeDateSubtitle = regexp.MustCompile(`^[^:]+:\s*\d{1,2}[/.\-]\d{1,2}[/.\-]\d{4}\s*$`)
+
+	// reSeriesPrefix strips "Series N: M. " from the start of a subtitle.
+	// This is redundant with the SxxExx numbering and confuses Sonarr's
+	// title parser (e.g. "S02E01.Series.2.1.Apex.Predator" fails to match).
+	reSeriesPrefix = regexp.MustCompile(`^Series\s+\d+:\s*\d+\.\s*`)
 )
 
 // isDateSubtitle reports whether s looks like a bare date (the only thing in
@@ -120,7 +125,7 @@ func GenerateTitle(p *store.Programme, quality string, override *store.ShowOverr
 
 func buildSxxExxTitle(name, episode string, series, ep int, quality string) string {
 	sn := sanitiseForTitle(name)
-	se := sanitiseForTitle(episode)
+	se := sanitiseForTitle(reSeriesPrefix.ReplaceAllString(episode, ""))
 	seNum := fmt.Sprintf("S%02dE%02d", series, ep)
 	if se != "" {
 		return fmt.Sprintf("%s.%s.%s.%s.WEB-DL.AAC.H264-%s", sn, seNum, se, quality, releaseGroup)


### PR DESCRIPTION
## Fixed

- **TVDB ID echoed in RSS responses** — `/newznab/?t=caps` now advertises `tvdbid`, and tvsearch results include `<newznab:attr name="tvdbid" />`. Sonarr can match definitively instead of parsing titles (fixes ambiguous names like "Return to Paradise").
- **Redundant `Series.N.M` stripped from release titles** — `S02E01.Series.2.1.Apex.Predator` → `S02E01.Apex.Predator`. Sonarr's parser handles the cleaner form.
- **Episode titles with colons** — `Series 2: 5. Chapter One: Murder` now splits only at the first `": "`, preserving the episode number.
- **Dashboard overflow** — active/queue sections cap at 400px/300px with thin internal scrollbars; page-level horizontal scroll restored.
- **Queue card appearing dynamically** — pending-download SSE events were routed to the active list; now correctly create the Queue card without a refresh.
- **Long titles truncate with ellipsis** in dashboard rows and history table.

## Files

- `internal/newznab/search.go`, `internal/newznab/titles.go`, `internal/bbc/ibl.go` — RSS + parser fixes
- `frontend/src/pages/Dashboard.tsx`, `frontend/src/styles.css` — dashboard UX
- `CHANGELOG.md`

## Verification

- `go build ./...` ✓, `go vet ./...` ✓
- Smoke test: built `iplayer-arr:v1.1.5-smoke`, ran on isolated loopback:63799 with tmpfs. `/health` → `ok`, `/newznab/?t=caps` → XML advertising `tvdbid` param. No errors in s6 startup.