### PR TITLE
docs: warn VPN_ENABLED=true requires NET_ADMIN + sysctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ volumes:
 ```
 
 > iPlayer requires a UK IP address. Enable the built-in VPN or run behind an existing UK VPN/proxy. See the [VPN Configuration](https://github.com/Will-Luck/iplayer-arr/wiki/VPN-Configuration) wiki page.
+>
+> **If you set `VPN_ENABLED=true`, the examples above are not sufficient.** You must also pass `--cap-add=NET_ADMIN` and `--sysctl net.ipv4.conf.all.src_valid_mark=1` (or the Compose equivalent) or the container will crash-loop at startup with `[VPN] Not the right capabilities`. Full example: [VPN Configuration → Docker Capabilities](https://github.com/Will-Luck/iplayer-arr/wiki/VPN-Configuration#docker-capabilities).
 
 Open `http://localhost:62001` and the setup wizard will guide you through connecting Sonarr.
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ When the auto-resolved numbering still doesn't match TheTVDB (common with specia
 
 > **Important**: You must hold a valid UK TV Licence to legally access BBC iPlayer content via iplayer-arr. iplayer-arr does not verify this and assumes you are compliant. See [DISCLAIMER.md](DISCLAIMER.md) for full legal terms.
 
+> **Running Unraid?** Install the Community Applications template from [Will-Luck/unraid-templates](https://github.com/Will-Luck/unraid-templates) rather than the `docker run` command below. The template pre-configures the VPN variables and the `NET_ADMIN` capabilities required when `VPN_ENABLED=true`.
+
 ```bash
 docker run -d \
   --name iplayer-arr \


### PR DESCRIPTION
## Why

Users copy/paste the Quick Start `docker run` example, set `VPN_ENABLED=true` from the Configuration section, and hit an immediate crash-loop with:

```
[VPN] Not the right capabilities, add [--cap-add=NET_ADMIN] and remove [--privileged=true] if set!
```

The wiki's [VPN Configuration → Docker Capabilities](https://github.com/Will-Luck/iplayer-arr/wiki/VPN-Configuration#docker-capabilities) documents the required flags, but the README only links to the wiki root — the warning is easy to miss.

## Change

One paragraph added under the existing VPN note in the Quick Start section, spelling out the two flags and linking directly to the Docker Capabilities anchor.

## Companion wiki PR

[`Troubleshooting.md`](https://github.com/Will-Luck/iplayer-arr/wiki/Troubleshooting#container-exits-at-startup-with-vpn-not-the-right-capabilities-add---cap-addnet_admin-and-remove---privilegedtrue-if-set) now has a dedicated troubleshooting entry for this exact error (wiki commit `6530252`).