### PR TITLE
ci: auto-publish GitHub Release on v* tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags: ['v*']
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 jobs:
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Generate build date
         id: build-date
@@ -64,3 +66,25 @@ jobs:
           repository: willluck/iplayer-arr
           short-description: BBC iPlayer Newznab indexer and SABnzbd download client for Sonarr
           readme-filepath: ./README.md
+
+      # Use the tag's annotation as the release body. Lightweight tags fall
+      # back to the tagged commit's subject. fetch-depth: 0 above is required
+      # so the tag object is available on the runner.
+      - name: Extract release notes from tag annotation
+        id: notes
+        run: |
+          set -euo pipefail
+          body=$(git for-each-ref --format='%(contents)' "refs/tags/${GITHUB_REF_NAME}")
+          if [ -z "$body" ]; then
+            body=$(git log -1 --pretty=%B "${GITHUB_REF_NAME}")
+          fi
+          printf '%s' "$body" > release-notes.md
+          echo "Wrote $(wc -c < release-notes.md) bytes to release-notes.md"
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          body_path: release-notes.md
+          make_latest: true

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 *.db
 *.partial.mp4
 .DS_Store
+
+.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Position-based episode identity now survives Sonarr's tvsearch filter (#32)**: BBC long-runners with no "Series N" subtitle prefix (Casualty, One Piece 1999) parsed to `Series=0, EpisodeNum=N` and were rejected by `matchesSearchFilter` because Sonarr always queries `season=1` for these shows. `iblResultToProgramme` now promotes `Series=1` whenever the subtitle gives a real episode number without a series prefix. Position alone does not trigger promotion (one-offs and specials also carry `Position>0`), so topical shows and genuine specials keep their existing date-tier and manual-tier handling.
+
 ### Changed
 
 - **Registry pages now carry README and OCI metadata.** Added `org.opencontainers.image.*` labels to the Dockerfile (title, description, source, url, documentation, licenses) so GHCR auto-links back to the repository. The release workflow now syncs `README.md` to Docker Hub's description field via `peter-evans/dockerhub-description@v4` on every `v*` tag push. Docker Hub's short description is set to "BBC iPlayer Newznab indexer and SABnzbd download client for Sonarr".

--- a/internal/newznab/handler_test.go
+++ b/internal/newznab/handler_test.go
@@ -866,3 +866,68 @@ func TestHandleTVSearch_TVDBIDRequestParamWinsOverStore(t *testing.T) {
 		t.Errorf("store tvdbid=99999 leaked over request tvdbid=78804, body:\n%s", body)
 	}
 }
+
+// GitHub #32. BBC long-runners with no "Series N" prefix in the subtitle
+// (Casualty: "Learning Curve Episode 3", One Piece 1999: "Episode 47 - ...")
+// parse to Series=0 + EpisodeNum=N via parseSubtitleNumbers. Sonarr sends
+// integer season/ep filters from the TVDB record; matchesSearchFilter then
+// rejects every item because prog.Series=0 != filterSeason=1.
+//
+// Fix: promote Series=1 at the identity-resolution boundary
+// (iblResultToProgramme) when Series=0 but EpisodeNum>0. Position alone
+// must NOT trigger promotion -- one-offs and specials have Position>0 but
+// no real episode numbering.
+func TestIblResultToProgramme_PromotesSeriesOneForPositionBasedShows(t *testing.T) {
+	cases := []struct {
+		name       string
+		in         bbc.IBLResult
+		wantSeries int
+		wantEpNum  int
+	}{
+		{"parsed episode, no series -> promote to series 1",
+			bbc.IBLResult{PID: "m001", Series: 0, EpisodeNum: 3}, 1, 3},
+		{"large parsed episode, no series -> still series 1",
+			bbc.IBLResult{PID: "m002", Series: 0, EpisodeNum: 147}, 1, 147},
+		{"explicit series, parsed episode -> leave series alone",
+			bbc.IBLResult{PID: "m003", Series: 2, EpisodeNum: 3}, 2, 3},
+		{"topical (no series, no episode, has airdate) -> leave at 0",
+			bbc.IBLResult{PID: "m004", Series: 0, EpisodeNum: 0, AirDate: "2026-04-01"}, 0, 0},
+		{"position-only, no parsed episode -> do NOT promote on Position alone",
+			bbc.IBLResult{PID: "m005", Series: 0, EpisodeNum: 0, Position: 5}, 0, 0},
+		{"series present but no episode -> leave as-is",
+			bbc.IBLResult{PID: "m006", Series: 3, EpisodeNum: 0}, 3, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := iblResultToProgramme(tc.in)
+			if got.Series != tc.wantSeries {
+				t.Errorf("Series = %d, want %d (input %+v)", got.Series, tc.wantSeries, tc.in)
+			}
+			if got.EpisodeNum != tc.wantEpNum {
+				t.Errorf("EpisodeNum = %d, want %d (input %+v)", got.EpisodeNum, tc.wantEpNum, tc.in)
+			}
+		})
+	}
+}
+
+// Regression for GitHub #32. Full path: a Casualty-shaped item (Series=0
+// from subtitle parsing, EpisodeNum=3 from "Episode 3") must survive
+// matchesSearchFilter when Sonarr queries season=1&ep=3.
+func TestMatchesSearchFilter_CasualtyPositionBasedAcceptsSeasonOne(t *testing.T) {
+	r := bbc.IBLResult{
+		PID:        "casualty-s01e03",
+		Title:      "Casualty",
+		Subtitle:   "Learning Curve Episode 3",
+		Series:     0,
+		EpisodeNum: 3,
+		AirDate:    "1986-09-20",
+	}
+	prog := iblResultToProgramme(r)
+	if !matchesSearchFilter(prog, "Casualty", "", 1, 3) {
+		t.Errorf("matchesSearchFilter rejected Casualty position-based item; prog=%+v", prog)
+	}
+	// And a mismatching episode should still be rejected.
+	if matchesSearchFilter(prog, "Casualty", "", 1, 4) {
+		t.Errorf("matchesSearchFilter wrongly accepted ep=4 for Casualty E3 item; prog=%+v", prog)
+	}
+}

--- a/internal/newznab/search.go
+++ b/internal/newznab/search.go
@@ -314,11 +314,23 @@ func writeEmptyRSS(w http.ResponseWriter) {
 }
 
 func iblResultToProgramme(r bbc.IBLResult) *store.Programme {
+	// Position-based identity promotion. BBC long-runners like Casualty
+	// and One Piece 1999 carry subtitles such as "Learning Curve Episode 3"
+	// that parseSubtitleNumbers reads as Series=0, EpisodeNum=3. Sonarr
+	// sends season=1 for these shows (their TVDB record has a single
+	// series), so matchesSearchFilter's Series==filterSeason gate rejects
+	// every item. Promote Series=1 whenever we have a real episode number
+	// but no series prefix. Position alone is not enough -- one-offs and
+	// specials also carry Position>0. GitHub #32.
+	series := r.Series
+	if series == 0 && r.EpisodeNum > 0 {
+		series = 1
+	}
 	return &store.Programme{
 		PID:        r.PID,
 		Name:       r.Title,
 		Episode:    r.Subtitle,
-		Series:     r.Series,
+		Series:     series,
 		EpisodeNum: r.EpisodeNum,
 		Position:   r.Position,
 		AirDate:    r.AirDate,


### PR DESCRIPTION
Release workflow was tagging + building but never calling the Releases API, so v1.1.6 and v1.1.7 had to be backfilled manually. This wires up the softprops/action-gh-release@v2 step.

- `contents: write` so the action can create releases.
- `fetch-depth: 0` on checkout so the tag object (and its annotation) is on the runner.
- Extract step writes the tag annotation to `release-notes.md`, falling back to the commit subject for lightweight tags.
- Publish step pins the tag as `latest`.

Does not backfill existing releases — just wires up future ones. Smoke verification has to wait until the next `v*` tag.